### PR TITLE
Add time.h in uapi/sound to prevent build error

### DIFF
--- a/include/sound/asound.h
+++ b/include/sound/asound.h
@@ -23,7 +23,7 @@
 #define __SOUND_ASOUND_H
 
 #include <linux/ioctl.h>
-#include <linux/time.h>
+// #include <linux/time.h>
 #include <asm/byteorder.h>
 
 #ifdef  __LITTLE_ENDIAN

--- a/include/uapi/sound/asound.h
+++ b/include/uapi/sound/asound.h
@@ -24,6 +24,7 @@
 #define _UAPI__SOUND_ASOUND_H
 
 #include <linux/types.h>
+#include <linux/time.h>
 
 
 /*


### PR DESCRIPTION
Lineage 15.1 throws error during building sound libraries.

Inserting
`#include <linux/time.h>` 
in 

> include/uapi/sound/asound.h 


resolves the issue
