### PR TITLE
shenqi_nv: drop the useless dump_smem function

### DIFF
--- a/drivers/soc/qcom/shenqi_nv.c
+++ b/drivers/soc/qcom/shenqi_nv.c
@@ -21,12 +21,6 @@ struct smem_nv {
 
 static struct smem_nv *psmem_nv = NULL;
 
-void dump_smem(struct smem_nv *buf)
-{
-	print_hex_dump(KERN_ALERT, "wifi   : ", DUMP_PREFIX_NONE, 16, 1,
-				   buf->nv_wifi, NV_WIFI_ADDR_SIZE, false);
-}
-
 static int smem_read_nv(void)
 {
 	struct smem_nv *buf;
@@ -44,13 +38,12 @@ static int smem_read_nv(void)
 	}
 
 	memcpy(psmem_nv, buf, sizeof(struct smem_nv));
-	dump_smem(psmem_nv);
 
 	return 0;
 }
 
 static long dump_wifi_addr(struct file *filp, char __user *buf,
-						   size_t count, loff_t *f_pos) 
+						   size_t count, loff_t *f_pos)
 {
 	loff_t pos = *f_pos;
 	int ret;
@@ -61,7 +54,7 @@ static long dump_wifi_addr(struct file *filp, char __user *buf,
 		return ret;
 	}
 
-	if (!psmem_nv) 
+	if (!psmem_nv)
 	{
 		printk(KERN_ERR "Could not get smem for wlan mac nv\n");
 		return 0;


### PR DESCRIPTION
* The dump_smem function more like a debug function which was implemented
  by the oem for debugging purposes but after the recent cleanup up
  DD3Boh/android_kernel_zuk_msm8996@4c947e4ab0bee7f79b3ab65132cf93749fb249b4 we now have proper fail checks so there is no need to have this function.

* Kill it with fire and drop the expense cost of calling it, also cleanup whitespaces while we are at it.

Signed-off-by: dev-harsh1998 <dev-harsh1998@hotmail.com>