### PR TITLE
Disable sensor pa_therm0

### DIFF
--- a/arch/arm/boot/dts/qcom/zuk/common.dtsi
+++ b/arch/arm/boot/dts/qcom/zuk/common.dtsi
@@ -353,3 +353,11 @@
 		};
 	};
 };
+
+&pm8994_vadc {
+	/delete-node/ chan@75;
+};
+
+&pm8994_adc_tm {
+	/delete-node/ chan@75;
+};


### PR DESCRIPTION
Its not a good idea to keep a sensor which stuck at -40 enable.
It only mess up userspace.
Disable it until we find a better solution.